### PR TITLE
Rework GH and AVH workflow to run without build.py

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -59,19 +59,11 @@ jobs:
       with:
         name: results
         path: |
-          basic/basic-*.zip
-          basic/basic-*.xunit
+          basic/Objects/basic.axf
+          basic/Objects/basic.axf.map
         retention-days: 1
         if-no-files-found: error
       if: always()
-
-    - name: Publish test results
-      uses: mikepenz/action-junit-report@v2
-      with:
-        check_name: "Test results"
-        report_paths: basic/basic-*.xunit
-      if: always()
-
 
   badge:
     if: always() && github.event_name == 'push'

--- a/basic/README.md
+++ b/basic/README.md
@@ -1,5 +1,5 @@
-[![Virtual Hardware Target](https://raw.githubusercontent.com/ARM-software/VHT-GetStarted/badges/.github/badges/basic.yml.vht.svg)](https://github.com/ARM-software/VHT-GetStarted/actions/workflows/basic.yml)
-![Unittest Results](https://raw.githubusercontent.com/ARM-software/VHT-GetStarted/badges/.github/badges/basic.yml.unittest.svg)
+[![Virtual Hardware Target](https://raw.githubusercontent.com/ARM-software/AVH-GetStarted/badges/.github/badges/basic.yml.vht.svg)](https://github.com/ARM-software/AVH-GetStarted/actions/workflows/basic.yml)
+![Unittest Results](https://raw.githubusercontent.com/ARM-software/AVH-GetStarted/badges/.github/badges/basic.yml.unittest.svg)
 
 # Arm Virtual Hardware - Basic Example
 
@@ -13,7 +13,7 @@ locally, for example with [CMSIS-Build](https://arm-software.github.io/CMSIS_5/d
 Automated test execution is managed with GitHub Actions and gets triggered on
 every code change in the repository. The program gets built and run on [Arm
 Virtual Hardware](https://www.arm.com/products/development-tools/simulation/virtual-hardware) cloud infrastructure in AWS and the test results can
-be then observed in repository's [GitHub Actions](https://github.com/ARM-software/VHT-GetStarted/actions).
+be then observed in repository's [GitHub Actions](https://github.com/ARM-software/AVH-GetStarted/actions).
 
 ## Example Structure
 
@@ -26,7 +26,7 @@ Folder or Files in the example   | Description
 `./basic.debug.cprj`             | Project file in [.cprj format](https://arm-software.github.io/CMSIS_5/Build/html/cprjFormat_pg.html)
 `./vht_config.txt`               | Configuration file for running the VHT model
 `./build.py`                     | Python script for project build, execution and analysis of test results
-`./vht.yml`                      | File with instructions for [VHT-AMI GitHub Action](https://github.com/ARM-software/VHT-AMI)
+`./avh.yml`                      | File with instructions for [AVH Client for Python](https://github.com/ARM-software/avhclient)
 `./requirements.txt`             | File with the list of Python packages required for execution of `./build.py`
 
 ## Prerequisites
@@ -101,26 +101,40 @@ repository into a local workspace.
 
 Open a command prompt in the local workspace. The following instructions assume
 Python is installed. If one doesn't want to go the Python way one can issue the
-individual command, manually.
+individual command, manually. The CMSIS-Build command `cbuild` and the Virtual
+Hardware Target executable `VHT_Corstone_SSE-300_Ethos-U55` are expected in the
+system `PATH`.
+
+In order to use the `build.py` script to conveniently execute the required commands,
+one need to install some Python requirements listed in `requirements.txt`:
 
 ```text
-~/VHT-GetStarted $ cd basic
-~/VHT-GetStarted/basic $ ./build.py -t debug cbuild
-[debug](cbuild:run_cbuild) bash -c 'source $(dirname $(which cbuild.sh))/../etc/setup; cbuild.sh basic.debug.cprj'
-[debug](cbuild:run_cbuild) basic.debug.cprj validates
-[debug](cbuild:run_cbuild) bash succeeded with exit code 0
+~/AVH-GetStarted/basic $ pip install -f requirements.txt
+```
+
+Once the required Python packages are installed one can run the script to
+build the example:
+
+```text
+~/AVH-GetStarted/basic $ ./build.py -t debug build
+[debug](build:run_cbuild) bash -c cbuild.sh --quiet basic.debug.cprj
+[debug](build:run_cbuild) bash succeeded with exit code 0
 
 Matrix Summary
 ==============
 
-target    cbuild    cpinstall    report    vht
---------  --------  -----------  --------  ------
-debug     success   (skip)       (skip)    (skip)
+target    build    run
+--------  -------  -----
+debug     success  (skip)
 
-~/VHT-GetStarted/basic $ ls -lah Objects/basic.axf
+~/AVH-GetStarted/basic $ ls -lah Objects/basic.axf
 
 -rw-r--r-- 1 **** 4096 64K Nov 25 10:59 Objects/basic.axf
 ```
+
+The `build.py` script automatically creates a timestamped archive of the build results
+in a file `basic-<timestamp>.zip`. One can extract this into another workspace at a
+later point in time to inspect the result, e.g. run the tests in a debugger.
 
 ### Execute on command line
 
@@ -129,61 +143,111 @@ Python is installed. If one don't want to go the Python way one can issue the
 individual command, manually.
 
 ```text
-~/VHT-GetStarted $ cd basic
-~/VHT-GetStarted/basic $ ./build.py -t debug vht
-[debug](vht:run_vht) VHT_Corstone_SSE-300_Ethos-U55 -q --cyclelimit 100000000 -f vht_config.txt Objects/basic.axf
-[debug](vht:run_vht) VHT_Corstone_SSE-300_Ethos-U55 succeeded with exit code 0
+~/AVH-GetStarted/basic $ ./build.py -t debug run
+[debug](run:run_vht) VHT_Corstone_SSE-300_Ethos-U55.EXE -q --stat --simlimit 1 -f vht_config.txt Objects/basic.axf
+[debug](run:run_vht) VHT_Corstone_SSE-300_Ethos-U55.EXE succeeded with exit code 0
+::set-output name=badge::Unittest-3%20of%204%20passed-yellow
 
 Matrix Summary
 ==============
 
-target    cbuild    cpinstall    report    vht
---------  --------  -----------  --------  -----
-debug     (skip)    (skip)       (skip)    3/4
+target    build    run
+--------  -------  -----
+debug     (skip)   3/4
 ```
 
 The summary lists out the number of test cases passed and totally executed.
-This example intentionally has one failing test case. Inspect the log to figure
-out which test case failed.
+This example intentionally has one failing test case. Inspect the xunit result
+file to see the details:
 
 ```text
-~/VHT-GetStarted/basic $ cat vht-20211125151037.log
-Fast Models [11.16.24 (Nov  4 2021)]
-Copyright 2000-2021 ARM Limited.
-All Rights Reserved.
-telnetterminal0: Listening for serial connection on port 5000
-telnetterminal1: Listening for serial connection on port 5001
-telnetterminal2: Listening for serial connection on port 5002
-telnetterminal5: Listening for serial connection on port 5003
-    Ethos-U rev afc78a99 --- Aug 31 2021 22:41:33
-    (C) COPYRIGHT 2019-2021 Arm Limited
-    ALL RIGHTS RESERVED
----[ UNITY BEGIN ]---
-C:/Users/jonant01/git/VHT-GetStarted/basic/main.c:44:test_my_sum_pos:PASS
-C:/Users/jonant01/git/VHT-GetStarted/basic/main.c:45:test_my_sum_neg:PASS
-C:/Users/jonant01/git/VHT-GetStarted/basic/main.c:38:test_my_sum_fail:FAIL: Expected 2 Was 0
-C:/Users/jonant01/git/VHT-GetStarted/basic/main.c:47:test_my_sum_zero:PASS
------------------------
-4 Tests 1 Failures 0 Ignored
-FAIL
----[ UNITY END ]---
-Info: Simulation is stopping. Reason: Cycle limit has been exceeded.
-Info: /OSCI/SystemC: Simulation stopped by user.
+~/AVH-GetStarted/basic $ cat basic-<timestamp>.xunit
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="1" tests="4" time="0.0">
+        <testsuite disabled="0" errors="0" failures="1" name="Cloud-CI basic tests" skipped="0" tests="4" time="0">
+                <testcase name="test_my_sum_pos" file="main.c" line="57"/>
+                <testcase name="test_my_sum_neg" file="main.c" line="58"/>
+                <testcase name="test_my_sum_fail" file="main.c" line="48">
+                        <failure type="failure" message="Expected 2 Was 0"/>
+                </testcase>
+                <testcase name="test_my_sum_zero" file="main.c" line="60"/>
+        </testsuite>
+</testsuites>
 ```
 
-This reveals that the test assertion in `main.c` line 38 failed.
+This reveals that the test assertion in `main.c` line 48 failed.
+
+### Understanding the `build.py` script
+
+The `build.py` script is written using the `python-matrix-runner` Python
+package. Find more detailed documentation for this Python package on its
+[PyPI page](https://pypi.org/project/python-matrix-runner/).
+
+This section puts some parts of the build script into the spotlight.
+
+#### Test report converter `class UnityReport`
+
+The `class UnityReport` is implemented as a `ReportFilter` so that it can
+later be used in a test report chain (see section about commands below).
+
+The relevant part here is `stream` property that receives a data stream
+(standard output of the model) and translates it into JUnit format. This
+is done by pattern matching (using regular expression) on the expected
+Unity framework output. Each found test case with its result is converted
+into a `junit_xml.TestCase` taken from the Python package `junit-xml`.
+
+#### Configuration axes `@matrix_axis`
+
+The `python-matrix-runner` has built-in support for matrix build configurations.
+In case of this trivial GetStarted example only a single configuration `debug`
+is used. This is done by specifying a project specific `Enum` per degree of
+freedom listing the configuration values. This example only has one axis
+(`target`) with one value (`debug`). More elaborated use-cases may add further
+axes for support of different compilers, optimization levels or target devices.
+
+#### Build actions `@matrix_action`
+
+The build script can offer different top-level actions the user can trigger
+from the command line. In this example these are only `build` and `run`. Each
+action is defined by the according method.
+
+An action method must at least `yield` one shell command to be executed.
+Complex actions can be composed from multiple shell commands interleaved
+with additional Python code. In this basic example additional Python code
+is used for some post-processing of the shell command results such as 
+creating an zip archive with the build output.
+
+#### Build commands `@matrix_command`
+
+Each shell command (required to compose the actions) is defined by a method
+returning an array with the command line parts, see
+[subprocess.run](https://docs.python.org/3.8/library/subprocess.html#subprocess.run)
+for details.
+
+A command can be further customized, for instance by attaching a `test_report`.
+The `test_report` is created by applying a chain of `ReportFiler`'s to the
+output of the command. In the basic example the output of the Virtual Hardware
+Target (VHT) model is captured (`ConsoleReport`), the Unity output between
+the known text markers is cropped (`CropReport`), and the remaining data
+is converted into JUnit format (`UnityReport`).
+
 
 ### Build and debug in MDK
 
-[Run with MDK-Professional](https://arm-software.github.io/VHT/main/infrastructure/html/run_mdk_pro.html) explains in details the tool setup and project configuration for running an MDK project on Arm Virtual Hardware.
+[Run with MDK-Professional](https://arm-software.github.io/AVH/main/infrastructure/html/run_mdk_pro.html)
+explains in details the tool setup and project configuration for running an
+MDK project on Arm Virtual Hardware.
 
-For this example, open the `basic.debug.uvprojx` file in MDK. Alternatively, the `basic.debug.cprj` can be imported as well.
+For this example, open the `basic.debug.uvprojx` file in MDK. Alternatively,
+the `basic.debug.cprj` can be imported as well.
 
 Before launching the debug session one needs to verify the debugger
 configuration. Bring up the _Options for target..._ dialog from the tool bar.
 Navigate to the _Debug_ pane and select _Use: Models ARMv8-M Debugger_. Next
 click on the _Settings_ button to bring up the _Models ARMv8-M Target Driver
-Setup_ dialog. Select in the as the _Command_ field the model executable for Corstone SSE-300 with Ethos-U55 (filename is: `VHT_Corstone_SSE-300_Ethos-U55.bat` in the location where Virtual Hardware models are installed).
+Setup_ dialog. Select in the as the _Command_ field the model executable for
+Corstone SSE-300 with Ethos-U55 (filename is: `VHT_Corstone_SSE-300_Ethos-U55.bat`
+in the location where Virtual Hardware models are installed).
 Set `cpu_core.cpu0` as the _Target_. Browse for the _Configuration File_ and
 select `vht_config.txt`.
 
@@ -203,20 +267,16 @@ above.
 
 On every change, the workflow is kicked off executing the following steps.
 
-- Create new EC2 instance\
-  A new EC2 instance of the VHT AMI is created on demand using the `aws`
-  command line interface. Creating (and terminating) the instance on demand
-  saves costs as AWS charges per use. The instance is not accessed directly
-  so it doesn't need a public IP address.
-- Execute build and test inside the EC2 instance\
-  The custom `Arm-Software/VHT-AMI` action is used to
+- Execute build and test inside an EC2 instance\
+  The [AVH Client for Python](https://github.com/ARM-software/avhclient) is used to
+  - create new EC2 instance
   - upload the workspace to the EC2 instance using a S3 storage bucket;
   - run the command line build;
   - execute the test image using the VHT model
   - download the output into the workspace.
+  - terminate the EC2 instance 
 - Extract and post-process test output, including
   - conversion of the log file into XUnit format.
-- Terminate the EC2 instance
 - Archive build/test output\
   The image, log file and XUnit report are attached as a build artifact for
   later analysis.

--- a/basic/avh.yml
+++ b/basic/avh.yml
@@ -15,9 +15,24 @@ upload:
   - vht_config.txt
   - README.md
 steps:
+  - run: cbuild.sh --quiet basic.debug.cprj
+  - run: VHT_Corstone_SSE-300_Ethos-U55 -q --stat --simlimit 1 -f vht_config.txt Objects/basic.axf | tee basic.stdout
   - run: |
-      pip install -r requirements.txt
-      python build.py --verbose build run
+      regex="([0-9]+) Tests ([0-9]+) Failures [0-9]+ Ignored"
+      result=$(grep -E "${regex}" basic.stdout)
+      if [[ ${result} =~ ${regex} ]]; then
+        tests="${BASH_REMATCH[1]}"
+        failures="${BASH_REMATCH[2]}"
+        passed=$(expr ${tests} - ${failures})
+        color="green"
+        if [[ ${failures} > 0 ]]; then
+          color="yellow"
+        fi
+        echo "::set-output name=badge::Unittest-${passed}%20of%20${tests}%20passed-${color}"
+      else
+        echo "::set-output name=badge::Unittest-failed-red"
+      fi
+      
 download:
   - RTE/**/RTE_Components.h
   - Objects/basic.axf


### PR DESCRIPTION
The drawbacks are:
- No junit xml result
- No build result zip archive
